### PR TITLE
NoSQL instance and its dependencies

### DIFF
--- a/SimpleNoSQL/src/androidTest/java/colintmiller/com/simplenosql/NoSQLDeleteTaskTest.java
+++ b/SimpleNoSQL/src/androidTest/java/colintmiller/com/simplenosql/NoSQLDeleteTaskTest.java
@@ -5,20 +5,21 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.test.ActivityUnitTestCase;
-import colintmiller.com.simplenosql.db.SimpleNoSQLContract;
-import colintmiller.com.simplenosql.db.SimpleNoSQLDBHelper;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+
+import colintmiller.com.simplenosql.db.SimpleNoSQLContract;
+import colintmiller.com.simplenosql.db.SimpleNoSQLDBHelper;
 
 /**
  * Tests to verify the deletion asyncTask performs as expected
  */
 public class NoSQLDeleteTaskTest extends ActivityUnitTestCase {
     private GsonSerialization serialization;
-    private Context context;
     private CountDownLatch signal;
+    private NoSQL noSQL;
 
     public NoSQLDeleteTaskTest() {
         super(Activity.class);
@@ -28,7 +29,8 @@ public class NoSQLDeleteTaskTest extends ActivityUnitTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        context = getInstrumentation().getTargetContext();
+        Context context = getInstrumentation().getTargetContext();
+        noSQL = NoSQL.with(context);
         signal = new CountDownLatch(1);
     }
 
@@ -58,7 +60,7 @@ public class NoSQLDeleteTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .addObserver(getObserver())
                         .save(entities);
             }
@@ -71,7 +73,7 @@ public class NoSQLDeleteTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .bucketId("delete")
                         .entityId("first")
                         .addObserver(getObserver())
@@ -107,7 +109,7 @@ public class NoSQLDeleteTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .addObserver(getObserver())
                         .save(lots);
             }
@@ -119,7 +121,7 @@ public class NoSQLDeleteTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .bucketId("delete")
                         .addObserver(getObserver())
                         .delete();

--- a/SimpleNoSQL/src/androidTest/java/colintmiller/com/simplenosql/NoSQLRetrieveTaskTest.java
+++ b/SimpleNoSQL/src/androidTest/java/colintmiller/com/simplenosql/NoSQLRetrieveTaskTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.test.ActivityUnitTestCase;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
@@ -17,6 +18,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
     private CountDownLatch signal;
     private List<NoSQLEntity<SampleBean>> results;
     private Context context;
+    private NoSQL noSQL;
 
     public NoSQLRetrieveTaskTest() {
         super(Activity.class);
@@ -38,6 +40,8 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
     public void setUp() throws Exception {
         super.setUp();
         this.context = getInstrumentation().getTargetContext();
+
+        noSQL = NoSQL.with(context);
 
         try {
             runTestOnUiThread(new Runnable() {
@@ -66,7 +70,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .bucketId(bucketId)
                         .retrieve(getCallback());
             }
@@ -85,7 +89,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .bucketId(bucketId)
                         .entityId(entityId)
                         .retrieve(getCallback());
@@ -128,7 +132,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .bucketId(bucketId)
                         .filter(filter)
                         .retrieve(getCallback());
@@ -182,7 +186,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .bucketId(bucketId)
                         .orderBy(comparator)
                         .retrieve(getCallback());
@@ -204,7 +208,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .retrieve(getCallback());
             }
         });
@@ -218,7 +222,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .addObserver(getObserver())
                         .save(new NoSQLEntity<SampleBean>("null", "nullitem"));
             }
@@ -229,7 +233,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .bucketId("null")
                         .entityId("nullitem")
                         .retrieve(getCallback());
@@ -254,7 +258,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, OldSampleBean.class)
+                noSQL.using(OldSampleBean.class)
                         .addObserver(getObserver())
                         .save(oldEntity);
             }
@@ -265,7 +269,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .bucketId("oldbucket")
                         .entityId("old")
                         .retrieve(getCallback());
@@ -285,7 +289,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         return new OperationObserver() {
             @Override
             public void hasFinished() {
-                signal.countDown();;
+                signal.countDown();
             }
         };
     }
@@ -302,7 +306,7 @@ public class NoSQLRetrieveTaskTest extends ActivityUnitTestCase {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .addObserver(new OperationObserver() {
 
                             @Override

--- a/SimpleNoSQL/src/androidTest/java/colintmiller/com/simplenosql/NoSQLSaveTaskTest.java
+++ b/SimpleNoSQL/src/androidTest/java/colintmiller/com/simplenosql/NoSQLSaveTaskTest.java
@@ -5,12 +5,13 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.test.ActivityUnitTestCase;
-import colintmiller.com.simplenosql.db.SimpleNoSQLContract;
-import colintmiller.com.simplenosql.db.SimpleNoSQLDBHelper;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+
+import colintmiller.com.simplenosql.db.SimpleNoSQLContract;
+import colintmiller.com.simplenosql.db.SimpleNoSQLDBHelper;
 
 /**
  * Tests for saving entities to the DB. This includes saving a single entity or saving multiple entities.
@@ -18,7 +19,7 @@ import java.util.concurrent.CountDownLatch;
 public class NoSQLSaveTaskTest extends ActivityUnitTestCase<Activity> {
     private GsonSerialization serialization;
     private CountDownLatch signal;
-    private Context context;
+    private NoSQL noSQL;
 
     public NoSQLSaveTaskTest() {
         super(Activity.class);
@@ -29,7 +30,8 @@ public class NoSQLSaveTaskTest extends ActivityUnitTestCase<Activity> {
     public void setUp() throws Exception {
         super.setUp();
         signal = new CountDownLatch(1);
-        this.context = getInstrumentation().getTargetContext();
+        Context context = getInstrumentation().getTargetContext();
+        noSQL = NoSQL.with(context);
     }
 
     public void testSaveEntity() throws Throwable {
@@ -42,7 +44,7 @@ public class NoSQLSaveTaskTest extends ActivityUnitTestCase<Activity> {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .addObserver(getObserver())
                         .save(entity);
             }
@@ -64,7 +66,7 @@ public class NoSQLSaveTaskTest extends ActivityUnitTestCase<Activity> {
 
     public void testSaveEntities() throws Throwable {
         final List<NoSQLEntity<SampleBean>> allEntities = new ArrayList<NoSQLEntity<SampleBean>>(3);
-        for(int i = 0; i < 3; i++) {
+        for (int i = 0; i < 3; i++) {
             NoSQLEntity<SampleBean> entity = new NoSQLEntity<SampleBean>("sample", "entity" + i);
             SampleBean data = new SampleBean();
             data.setId(i);
@@ -76,7 +78,7 @@ public class NoSQLSaveTaskTest extends ActivityUnitTestCase<Activity> {
         runTestOnUiThread(new Runnable() {
             @Override
             public void run() {
-                NoSQL.with(context, SampleBean.class)
+                noSQL.using(SampleBean.class)
                         .addObserver(getObserver())
                         .save(allEntities);
             }
@@ -96,7 +98,7 @@ public class NoSQLSaveTaskTest extends ActivityUnitTestCase<Activity> {
 
         assertEquals(cursor.getCount(), 3);
         int counter = 0;
-        while(cursor.moveToNext()) {
+        while (cursor.moveToNext()) {
             String data = cursor.getString(cursor.getColumnIndex(SimpleNoSQLContract.EntityEntry.COLUMN_NAME_DATA));
             NoSQLEntity<SampleBean> bean = new NoSQLEntity<SampleBean>("bucket", "id");
             bean.setData(serialization.deserialize(data, SampleBean.class));
@@ -110,7 +112,7 @@ public class NoSQLSaveTaskTest extends ActivityUnitTestCase<Activity> {
         return new OperationObserver() {
             @Override
             public void hasFinished() {
-                signal.countDown();;
+                signal.countDown();
             }
         };
     }

--- a/SimpleNoSQL/src/androidTest/java/colintmiller/com/simplenosql/TestUtils.java
+++ b/SimpleNoSQL/src/androidTest/java/colintmiller/com/simplenosql/TestUtils.java
@@ -12,7 +12,7 @@ public class TestUtils {
     public static CountDownLatch cleanBucket(String bucket, Context context) {
         final CountDownLatch signal = new CountDownLatch(1);
 
-        NoSQL.with(context, TestUtils.class)
+        NoSQL.with(context).using(TestUtils.class)
                 .bucketId(bucket)
                 .addObserver(new OperationObserver() {
                     @Override

--- a/SimpleNoSQL/src/main/java/colintmiller/com/simplenosql/NoSQL.java
+++ b/SimpleNoSQL/src/main/java/colintmiller/com/simplenosql/NoSQL.java
@@ -7,28 +7,36 @@ import android.content.Context;
  * Simple access to a NoSQL store. You can save, retrieve, and delete any entity. Saving performs an insert
  * or an update (overwriting previous data). All calls are done asynchronously. Due to this, retrieving data
  * requires a callback.<p>
- *
+ * <p/>
  * Data is stored locally via serialization to a String. By default, the Gson library is used to convert objects to
  * JSON. You may provide custom serializers and deserializers by implementing the
  * {@link colintmiller.com.simplenosql.DataSerializer} and {@link colintmiller.com.simplenosql.DataDeserializer}
  * interfaces and supplying them on construction.
  */
-public class NoSQL
-{
-    private static DataSerializer serializer;
-    private static DataDeserializer deserializer;
+public class NoSQL {
 
+    static NoSQL singleton = null;
+
+    final Context context;
+    final DataSerializer serializer;
+    final DataDeserializer deserializer;
+
+    NoSQL(Context context, DataSerializer serializer, DataDeserializer deserializer) {
+        this.context = context;
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+    }
 
     /**
      * Get a builder for performing some sort of data operation. This builder can be used for retrieval, saving, or
      * deletion of data. See {@link colintmiller.com.simplenosql.QueryBuilder} for more information on how to build
      * a query.
-     * @param context to use for this operation.
+     *
      * @param clazz related to this operation. This would be the class of the objects you're saving or retrieving.
-     * @param <T> the type of the objects used in this operation.
+     * @param <T>   the type of the objects used in this operation.
      * @return a {@link colintmiller.com.simplenosql.QueryBuilder}.
      */
-    public static <T> QueryBuilder<T> with(Context context, Class<T> clazz) {
+    public <T> QueryBuilder<T> using(Class<T> clazz) {
         QueryBuilder<T> builder = new QueryBuilder<T>(context, clazz);
         if (serializer != null) {
             builder.serializer(serializer);
@@ -40,25 +48,46 @@ public class NoSQL
         return builder;
     }
 
-    /**
-     * By default, SimpleNoSQL will use Google's Gson library for serialization and deserialization. You may override
-     * this globally here by registering a DataSerializer with whatever serialization method you'd like to use. If you
-     * register both a Serializer and Deserializer before making any database calls, you may safely remove gson as
-     * a dependency.
-     * @param serializer to use in all future NoSQL requests.
-     */
-    public static void registerSerializer(DataSerializer serializer) {
-        NoSQL.serializer = serializer;
+    public static NoSQL with(Context context) {
+        if (singleton == null) {
+            synchronized (NoSQL.class) {
+                if (singleton == null) {
+                    singleton = new Builder(context).build();
+                }
+            }
+        }
+        return singleton;
     }
 
-    /**
-     * By default, SimpleNoSQL will use Google's Gson library for serialization and deserialization. You may override
-     * this globally here by registering a DataSerializer with whatever serialization method you'd like to use. If you
-     * register both a Serializer and Deserializer before making any database calls, you may safely remove gson as
-     * a dependency.
-     * @param deserializer to use in all future NoSQL requests.
-     */
-    public static void registerDeserializer(DataDeserializer deserializer) {
-        NoSQL.deserializer = deserializer;
+    public static class Builder {
+        private final Context context;
+        private DataSerializer serializer;
+        private DataDeserializer deserializer;
+
+        public Builder(Context context) {
+            this.context = context;
+        }
+
+        public Builder serializer(DataSerializer serializer) {
+            this.serializer = serializer;
+            return this;
+        }
+
+        public Builder deserializer(DataDeserializer deserializer) {
+            this.deserializer = deserializer;
+            return this;
+        }
+
+        public NoSQL build() {
+            if (serializer == null) {
+                serializer = new GsonSerialization();
+            }
+
+            if (deserializer == null) {
+                serializer = new GsonSerialization();
+            }
+
+            return new NoSQL(context, serializer, deserializer);
+        }
     }
 }


### PR DESCRIPTION
What about single NoSQL instance for context? sounds like a great idea.
Same for serializer/deserializer as optional dependency.

Like:
new NoSQL(context);
new NoSQL(context, serializer, deserializer); //maybe a single interface for both?

take a look at Picasso instance creation for example. Builder.
https://github.com/square/picasso/blob/master/picasso/src/main/java/com/squareup/picasso/Picasso.java#L491

Why its good?
i dont need to provide context and my (de)serializers on every call.

Do we still need NoSQL.with(context)? 
Yes.

Im not sure about .using() method name.
