### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/SimpleNoSQL/src/androidTest/java/com/colintmiller/simplenosql/TestUtils.java
+++ b/SimpleNoSQL/src/androidTest/java/com/colintmiller/simplenosql/TestUtils.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CountDownLatch;
  * Created by cmiller on 8/12/14.
  */
 public class TestUtils {
+    private TestUtils() {}
 
     public static CountDownLatch cleanBucket(String bucket, Context context) {
         final CountDownLatch signal = new CountDownLatch(1);

--- a/SimpleNoSQL/src/main/java/com/colintmiller/simplenosql/db/SimpleNoSQLContract.java
+++ b/SimpleNoSQL/src/main/java/com/colintmiller/simplenosql/db/SimpleNoSQLContract.java
@@ -6,7 +6,7 @@ import android.provider.BaseColumns;
  * The basic contract for our DB's that SimpleNoSQL will use to store user data.
  */
 public class SimpleNoSQLContract {
-    public SimpleNoSQLContract() {}
+    private SimpleNoSQLContract() {}
 
     public static abstract class EntityEntry implements BaseColumns {
         public static final String TABLE_NAME = "simplenosql";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.