### PR TITLE
Update Readme to correct not close "<" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ NoSQL.with(context).using(SampleBean.class)
     .bucketId("bucket")
     .entityId("entityId")
     .retrieve(new RetrievalCallback<SampleBean>() {
-    public void retrieveResults(List<NoSQLEntity<SampleBean> entities) {
+    public void retrieveResults(List<NoSQLEntity<SampleBean>> entities) {
         // Display results or something 
         SampleBean firstBean = entities.get(0).getData(); // always check length of a list first...
     }   


### PR DESCRIPTION
```java
NoSQL.with(context).using(SampleBean.class)
    .bucketId("bucket")
    .entityId("entityId")
    .retrieve(new RetrievalCallback<SampleBean>() {
    public void retrieveResults(List<NoSQLEntity<SampleBean>> entities) {
        // Display results or something 
        SampleBean firstBean = entities.get(0).getData(); // always check length of a list first...
    }   
});
In this code the writter forgot to close the "<" and this caused errors when the code is used. Hereby the error is corrected from the readme.