### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.colintmiller:simplenosql:0.5.1'
+    implementation 'com.colintmiller:simplenosql:0.5.1'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.